### PR TITLE
Added missing description

### DIFF
--- a/_posts/2017-04-27-Swift-3-Лекция-7.md
+++ b/_posts/2017-04-27-Swift-3-Лекция-7.md
@@ -78,6 +78,7 @@ protocol Printable {
 }
 	
 class Machine: Printable {
+	var description = ""
 	var powerConsumption = 0
 	var name = "Missing name"
 	static var version: String = "v. 2.0"


### PR DESCRIPTION
protocol requires property 'description' with type 'String'